### PR TITLE
Feature: Execution Report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
 build
+
+yarn-error.log

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Options:
     --done-criteria=regex           consider the process "done" when output line matches regex
     --exclude pkgname               skip actually running the script for that package
     --exclude-missing               skip packages which lack the specified script
+    --report                        show an execution report once all scripts are finished
 ```
 
 ### Examples:

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import * as Promise from 'bluebird'
 import * as fs from 'fs'
 import { argv } from 'yargs'
 import * as _ from 'lodash'
+import chalk from 'chalk'
 
 import { RunGraph } from './parallelshell'
 import { listPkgs } from './workspace'
@@ -81,7 +82,16 @@ if (cycle.length > 0) {
 let runlist = argv._.slice(1)
 runner.run(cmd, runlist.length > 0 ? runlist : undefined).then(hadError => {
   if (hadError && fastExit) {
-    console.error('Aborting execution due to previous error')
-    process.exit(1)
+    console.error(
+      chalk.red(
+        `\nAborting execution and cancelling running scripts because an error occurred executing \`${cmd}\` for one of the packages.`
+      )
+    )
+    console.error(
+      '  Run wsrun without option --fast-exit to keep going despite errors or with option --report to see which package caused the error.\n'
+    )
+    console.error()
   }
+
+  process.exit(hadError ? 1 : 0)
 })

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,8 @@ const exclude: string[] =
 
 const excludeMissing = argv.excludeMissing || false
 
+const showReport: boolean = argv.report || false
+
 const cmd = argv._[0]
 const pkgName = argv._[1]
 
@@ -64,6 +66,7 @@ let runner = new RunGraph(
     doneCriteria,
     exclude,
     excludeMissing,
+    showReport,
     workspacePath: process.cwd()
   },
   pkgPaths
@@ -76,7 +79,9 @@ if (cycle.length > 0) {
 }
 
 let runlist = argv._.slice(1)
-runner.run(cmd, runlist.length > 0 ? runlist : undefined).catch(err => {
-  console.error('Aborting execution due to previous error')
-  process.exit(1)
+runner.run(cmd, runlist.length > 0 ? runlist : undefined).then(hadError => {
+  if (hadError && fastExit) {
+    console.error('Aborting execution due to previous error')
+    process.exit(1)
+  }
 })

--- a/src/parallelshell.ts
+++ b/src/parallelshell.ts
@@ -204,6 +204,7 @@ export class RunGraph {
     public pkgPaths: Dict<string>
   ) {
     this.checkResultsAndReport = this.checkResultsAndReport.bind(this)
+    this.closeAll = this.closeAll.bind(this)
 
     pkgJsons.forEach(j => this.jsonMap.set(j.name, j))
     this.children = []
@@ -303,7 +304,7 @@ export class RunGraph {
         child.start()
         return child.finished
       })
-      // return this.opts.mode != 'parallel' ? finished : Promise.resolve()
+
       return finished
     })
   }
@@ -401,7 +402,7 @@ export class RunGraph {
   run(cmd: string, pkgs: string[] = this.pkgJsons.map(p => p.name)) {
     this.runList = new Set(pkgs)
     return Promise.all(pkgs.map(pkg => this.lookupOrRun(cmd, pkg)))
-      .catch(err => this.opts.fastExit && this.closeAll.apply(this))
+      .catch(err => this.opts.fastExit && this.closeAll())
       .then(() => this.checkResultsAndReport(cmd, pkgs))
   }
 }


### PR DESCRIPTION
Here's a few screenshots of what the report described in #14 could look like:

<img width="649" alt="wsrun-fast-exit" src="https://user-images.githubusercontent.com/5621996/36818699-3c7483de-1cb4-11e8-8b6a-b47e909f0bff.png">
<img width="649" alt="wsrun-skip-missing" src="https://user-images.githubusercontent.com/5621996/36818701-3c95c04e-1cb4-11e8-9cfd-7eb0d4a4324a.png">

Unfortunately, showing exit codes seems a bit pointless, since at least in my test yarn always seemed to be returning `1` on error, no matter what code the underlying script returned. I'll look into this a bit more.

What do you think? @spion 