### PR TITLE
Allow workspaces in new format

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -46,7 +46,10 @@ if (!cmd) {
 
 type BuildInstr = { name: string; order: number; cycle: boolean }
 
-const workspaceGlobs = JSON.parse(fs.readFileSync('./package.json', 'utf8')).workspaces || [
+const packageJsonWorkspaces = JSON.parse(fs.readFileSync('./package.json', 'utf8')).workspaces
+const packageJsonWorkspacesNohoistFormat = packageJsonWorkspaces && packageJsonWorkspaces.packages
+
+const workspaceGlobs = packageJsonWorkspacesNohoistFormat || packageJsonWorkspaces || [
   'packages/*'
 ]
 


### PR DESCRIPTION
Yarn has introduced a new format for workspaces:
https://yarnpkg.com/blog/2018/02/15/nohoist/

Make sure we allow this new format when finding the packages globs