### PR TITLE
removed extra space in skipping missing log output

### DIFF
--- a/src/run-graph.ts
+++ b/src/run-graph.ts
@@ -178,7 +178,7 @@ export class RunGraph {
         return Bromise.resolve(ProcResolution.Excluded)
       }
       if (this.opts.excludeMissing && (!p || !p.scripts || !p.scripts[cmdArray[0]])) {
-        console.log(chalk.bold(pkg), 'has no ', cmdArray[0], 'script, skipping missing')
+        console.log(chalk.bold(pkg), 'has no', cmdArray[0], 'script, skipping missing')
         this.resultMap.set(pkg, ResultSpecialValues.MissingScript)
         return Bromise.resolve(ProcResolution.Missing)
       }


### PR DESCRIPTION
we'll no longer see "package has no  scriptname script [...]"