### PR TITLE
Issue 28: Propagate exit codes when combining --serial and --fast-exit

### DIFF
--- a/src/enums.ts
+++ b/src/enums.ts
@@ -1,0 +1,15 @@
+export enum ResultSpecialValues {
+    Pending = 'PENDING',
+    Excluded = 'EXCLUDED',
+    MissingScript = 'MISSING_SCRIPT',
+    NotStarted = 'NOT_STARTED',
+    Cancelled = 'CANCELLED'
+}
+
+export type Result = number | ResultSpecialValues
+
+export enum ProcResolution {
+    Normal = 'Normal',
+    Missing = 'Missing',
+    Excluded = 'Excluded'
+}

--- a/src/run-graph.ts
+++ b/src/run-graph.ts
@@ -1,12 +1,9 @@
-/**
- * Remove me.
- */
-
 import * as Bromise from 'bluebird'
 import chalk from 'chalk'
 import * as path from 'path'
 
 import { PkgJson, Dict } from './workspace'
+import { ResultSpecialValues, Result, ProcResolution } from './enums';
 import { uniq } from 'lodash'
 import { inherits } from 'util'
 import { CmdProcess } from './cmd-process'
@@ -51,19 +48,6 @@ export interface GraphOptions {
   if: string
   ifDependency: boolean
   concurrency: number | null
-}
-
-enum ResultSpecialValues {
-  Pending = 'PENDING',
-  Excluded = 'EXCLUDED',
-  MissingScript = 'MISSING_SCRIPT'
-}
-type Result = number | ResultSpecialValues
-
-enum ProcResolution {
-  Normal = 'Normal',
-  Missing = 'Missing',
-  Excluded = 'Excluded'
 }
 
 export class RunGraph {
@@ -332,8 +316,8 @@ export class RunGraph {
         .then(() => Bromise.all(this.children.map(c => c.exitError)))
         // If any of them do, and fastExit is enabled, stop every other
         .catch(_err => this.opts.fastExit && this.closeAll())
-        // Wait for the exit codes of all processes
-        .then(() => Bromise.all(this.children.map(c => c.exitCode)))
+        // Wait for the all the processes to finish
+        .then(() => Bromise.all(this.children.map(c => c.result)))
         // Generate report
         .then(() => this.checkResultsAndReport(cmd, pkgs))
     )


### PR DESCRIPTION
So what happens here is that the CmdProcesses are added to the .children array well before they are actually started. In serial+fast-exit, the whole thing is called off before they start. Hence exitCode doesn't correspond to any resolvable promise, and the the whole thing unravels [1], and the process exits before .checkResultsAndReport can be called, let alone process.exit(1).

[1] https://stackoverflow.com/questions/46914025/node-exits-without-error-and-doesnt-await-promise-event-callback

Replace waiting on exitCode with waiting on generalised "result" (which might be "Cancelled", or a normal code), to handle cases where a command might be cancelled before it starts/finishes.